### PR TITLE
Disable `chroot` in SFTP container to avoid 100% CPU in Fedora

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,8 +63,13 @@ services:
     restart: always
     ports:
       - "127.0.0.1:2222:22"
+    entrypoint: "/bin/bash"
+    # Disable chroot to avoid 100% CPU in Fedora:
+    # - https://unix.stackexchange.com/q/729987/144328
+    # - https://scvalex.net/posts/56/
     command:
-      - "foo:bar:1000:1000:upload"
+      - "-c"
+      - "sed -i '/ChrootDirectory/d' /etc/ssh/sshd_config && /entrypoint foo:bar:1000:1000:upload"
 
   minio:
     image: minio/minio

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@chehsunliu/seeder-monorepo",
-  "version": "0.1.0",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@chehsunliu/seeder-monorepo",
-      "version": "0.1.0",
+      "version": "0.0.0",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chehsunliu/seeder-monorepo",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.0.0",
   "description": "A Node.js library for data seeding, making data preparation for integration testing easier",
   "author": "Che-Hsun Liu <chehsunliu@gmail.com>",
   "license": "MIT",

--- a/packages/seeder-sftp/tests/setup.ts
+++ b/packages/seeder-sftp/tests/setup.ts
@@ -12,7 +12,7 @@ seederManager.configure([
       password: "bar",
     },
     localSrcDir: "sftp",
-    sftpDestDir: "/upload",
+    sftpDestDir: "upload",
   }),
 ]);
 

--- a/packages/seeder-sftp/tests/sftp-seeder.test.ts
+++ b/packages/seeder-sftp/tests/sftp-seeder.test.ts
@@ -26,8 +26,8 @@ describe("basics", () => {
   });
 
   it("loads data", async () => {
-    expect((await client.get("/upload/a.txt")).toString().trimEnd()).toBe("321");
-    expect((await client.get("/upload/b/c.txt")).toString().trimEnd()).toBe("cba");
+    expect((await client.get("./upload/a.txt")).toString().trimEnd()).toBe("321");
+    expect((await client.get("./upload/b/c.txt")).toString().trimEnd()).toBe("cba");
   });
 });
 


### PR DESCRIPTION
References:
- https://unix.stackexchange.com/q/729987/144328
- https://scvalex.net/posts/56/